### PR TITLE
opackage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssotme",
-  "version": "2025.06.16",
+  "version": "2025.06.17",
   "dotnet": "8.0.410",
   "description": "",
   "bin": {


### PR DESCRIPTION
# Fixed bugs:

 - baserow tokens not refreshing bug when using -buildontrigger -copilotconnect
 - ODXML files not generating in builds on macs in some scenarios
 - found another reference to 'cmd' in checkResults - changed it to also include 'bin/bash/' for nonwindows installations
 
 # Improvements
 
 - some errors, like "project is null", will no longer show a dotnet stack trace